### PR TITLE
Find executable and execute it

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -5,6 +5,7 @@
 #define ROOTSH_MAX_ARG_LENGTH 100
 #define ROOTSH_MAX_ERROR_LENGTH 256
 #define PATHVAR "PATH"
+#define WORKINGDIRVAR "PWD"
 
 #ifndef TRUE
 #define TRUE 1

--- a/src/constants.h
+++ b/src/constants.h
@@ -18,7 +18,7 @@
 #include <stdio.h>
 
 #define ASSERT(op)           \
-    if((op) == 0) {          \
+    if((op) == FALSE) {          \
         fprintf(stderr, "Error: line %d, file \"%s\"\n", __LINE__, __FILE__);   \
         fflush(stderr);     \
         exit(EXIT_FAILURE); \

--- a/src/error.c
+++ b/src/error.c
@@ -2,6 +2,7 @@
 
 Error rootshError_new_error() {
     Error err = (Error)malloc(sizeof(char*));
+    *err = NULL;
     return err;
 }
 

--- a/src/error.c
+++ b/src/error.c
@@ -6,11 +6,10 @@ Error rootshError_new_error() {
 }
 
 void rootshError_destroy_error(Error err) {
+    if (*err != NULL)
+        free(*err);
+    
     free(err);
-}
-
-void rootshError_destroy_error_message(Error err) {
-    free(*err);
 }
 
 void rootshError_set_error_message(Error err, const char *message) {
@@ -27,5 +26,12 @@ void rootshError_set_error_with_argument(Error err, const char* message, char* a
 
 void rootshError_print_error(Error err) {
     printf("%s", *err);
-    rootshError_destroy_error_message(err);
+}
+
+void rootshError_print_new_error(char *message) {
+    Error err = rootshError_new_error();
+    rootshError_set_error_message(err, message);
+    rootshError_print_error(err);
+    rootshError_destroy_error(err);
+    return;
 }

--- a/src/error.c
+++ b/src/error.c
@@ -26,7 +26,7 @@ void rootshError_set_error_with_argument(Error err, const char* message, char* a
 }
 
 void rootshError_print_error(Error err) {
-    printf("%s", *err);
+    fprintf(stderr, "%s", *err);
 }
 
 void rootshError_print_new_error(char *message) {

--- a/src/error.h
+++ b/src/error.h
@@ -8,16 +8,51 @@
 
 typedef char** Error;
 
+/**
+ * Create a new error
+ * 
+ * @return An error with a empty message
+ */
 Error rootshError_new_error();
 
+/**
+ * Free an error
+ * 
+ * @param err   The error to free
+ */
 void rootshError_destroy_error(Error err);
 
-void rootshError_destroy_error_message(Error err);
-
+/**
+ * Set the message of an error
+ *
+ * @param err The error to put the message in
+ * @param message The message to put in the error
+ */
 void rootshError_set_error_message(Error err, const char *message);
 
+/**
+ * Set the message of an error with an argument. 
+ * The message will be a concatenated string in the form :
+ * `[Error] <message> : <argument>`
+ * 
+ * @param err The error to put the message in
+ * @param message The message to put in the error
+ * @param arg The argument to put at the end of a message
+ */
 void rootshError_set_error_with_argument(Error err, const char *message, char *arg);
 
+/**
+ * Print the error message on the out stream STDOUT
+ * 
+ * @param err The error to print
+ */
 void rootshError_print_error(Error err);
+
+/**
+ * Print an error message directly from a string
+ * 
+ * @param message The message to put on the error
+ */
+void rootshError_print_new_error(char* message);
 
 #endif

--- a/src/execCommand.c
+++ b/src/execCommand.c
@@ -34,58 +34,57 @@ List getEnvironementsDir()
     return paths;
 }
 
-char* get_single_command_from_paths(List command, List paths) {
+/**
+ * Check in every directory of environement variable "PATH" if the command "command" is in it
+ * 
+ * @param command The name of the command to search
+ * @param paths The list of every paths from the "PATH" env var (in the form of a `rootshList`)
+ * @return The full path to the command
+ */
+char* get_single_command_from_env_paths(char* command, List paths) {
     char* executablePath = (char*)malloc(sizeof(char) * PATH_MAX);
     int found = 0;
 
-    // if is a file, go to that location
-    if (ISFILE(command)) {
-        
-    }
+    DIR* dir;
 
-    // if not a file, check for executables in "PATH"
-    else {
-        DIR* dir;
-
-        // open every "PATH" directories
-        List currentDir = paths;
-        while (currentDir != NULL && !found) {
-            // open dir
-            dir = opendir(currentDir->v);
-            if (dir==NULL) {
-                // if dir not found, skip to next dir
-                if (errno == 2) {
-                    currentDir = currentDir->next;
-                    continue;
-                }
-
-                // uknown error, stop
-                else {
-                    printf("Errno : %d\n", errno);
-                    ASSERT(FALSE);
-                }
+    // open every "PATH" directories
+    List currentDir = paths;
+    while (currentDir != NULL && !found) {
+        // open dir
+        dir = opendir(currentDir->v);
+        if (dir==NULL) {
+            // if dir not found, skip to next dir
+            if (errno == ENOENT) {
+                currentDir = currentDir->next;
+                continue;
             }
 
-            struct dirent* file = readdir(dir);
-
-            // check for every file in directory
-            while (file != NULL && !found) {
-
-                // check file name
-                if (strncmp(file->d_name, command->v, NAME_MAX) == 0){
-                    found = 1;
-                    snprintf(executablePath, PATH_MAX, "%s/%s", (char*)currentDir->v, file->d_name);
-                }
-
-                // swap to next file in directory
-                errno = 0;
-                file = readdir(dir);
+            // uknown error, stop
+            else {
+                printf("Errno : %d\n", errno);
+                ASSERT(FALSE);
             }
-
-            ASSERT(closedir(dir) != -1);
-
-            currentDir = currentDir->next;
         }
+
+        struct dirent* file = readdir(dir);
+
+        // check for every file in directory
+        while (file != NULL && !found) {
+
+            // check file name
+            if (strncmp(file->d_name, command, NAME_MAX) == 0){
+                found = 1;
+                snprintf(executablePath, PATH_MAX, "%s/%s", (char*)currentDir->v, file->d_name);
+            }
+
+            // swap to next file in directory
+            errno = 0;
+            file = readdir(dir);
+        }
+
+        ASSERT(closedir(dir) != -1);
+
+        currentDir = currentDir->next;
     }
 
     if (found==0) {
@@ -96,14 +95,16 @@ char* get_single_command_from_paths(List command, List paths) {
     return executablePath;
 }
 
-void rootshExec_execute_command(char* command) {
+// main function
+void rootshExec_execute_command(char* commandStr) {
     List paths = getEnvironementsDir();
 
     // parse the command
-    List commands = rootshInput_splitInput(command);
+    List commands = rootshInput_splitInput(commandStr);
 
     for (List command=commands; command!=NULL; command=command->next) {
         List currentCommand = command->v;
+        char* executable = NULL;
 
         // Check redirection
         Error errorRedirect = rootshError_new_error();
@@ -119,13 +120,21 @@ void rootshExec_execute_command(char* command) {
         rootshError_destroy_error(errorRedirect);
 
         // Check file
+        if (ISFILE(currentCommand)) {
+            executable = currentCommand->v;
+        }
 
         // Check "PATH" executables
-        char* executable = get_single_command_from_paths(currentCommand, paths);
+        else {
+            executable = get_single_command_from_env_paths(currentCommand->v, paths);
+        }
 
         if (executable==NULL) {
             // set error & print it
-            rootshError_print_new_error("Command not found");
+            Error err = rootshError_new_error();
+            rootshError_set_error_with_argument(err, "Command not found", currentCommand->v);
+            rootshError_print_error(err);
+            rootshError_destroy_error(err);
 
             // free everything
             rootshList_destroy2DListAll(commands);
@@ -151,7 +160,6 @@ void rootshExec_execute_command(char* command) {
                 for (int i=0; i<nbArguments; i++) {
                     arguments[i] = tmp->v;
                     tmp = tmp->next;
-                    printf("%s\n", arguments[i]);
                 }
                 arguments[nbArguments] = (char*)NULL; // required for execv
 
@@ -162,6 +170,7 @@ void rootshExec_execute_command(char* command) {
                 rootshList_destroy2DListAll(commands);
                 rootshList_destroyAll(paths);
                 free(executable);
+                free(arguments);
 
                 exit(exitStatus);
                 break;
@@ -174,9 +183,25 @@ void rootshExec_execute_command(char* command) {
         // wait for the child process to execute
         int childStatus;
         ASSERT(wait(&childStatus) != -1);
-        if (WIFEXITED(childStatus) && WEXITSTATUS(childStatus) == -1) {
-            rootshError_print_new_error("An unexpected error happened while executing the command");
-            return;
+        if (WIFEXITED(childStatus)) {
+
+            // check child return code
+            switch (WEXITSTATUS(childStatus)) {
+            case 0: // no error    
+                break;
+            case EACCES: // permission denied
+                rootshError_print_new_error("Permission denied");
+                break;
+            
+            default:
+                char errnoNb[5];
+                snprintf(errnoNb, 5, "%d", WEXITSTATUS(childStatus));
+
+                Error err = rootshError_new_error();
+                rootshError_set_error_with_argument(err, "Unexcpected error. ERRNO", errnoNb);
+                rootshError_print_new_error("An unexpected error happened while executing the command");
+                break;
+            }
         }
 
         // free the path of the executable

--- a/src/execCommand.c
+++ b/src/execCommand.c
@@ -121,7 +121,8 @@ void rootshExec_execute_command(char* commandStr) {
 
         // Check file
         if (ISFILE(currentCommand)) {
-            executable = currentCommand->v;
+            executable = (char*)malloc(sizeof(char) * ROOTSH_MAX_ARG_LENGTH);
+            snprintf(executable, ROOTSH_MAX_ARG_LENGTH, "%s", (char*)currentCommand->v);
         }
 
         // Check "PATH" executables
@@ -172,7 +173,10 @@ void rootshExec_execute_command(char* commandStr) {
                 free(executable);
                 free(arguments);
 
-                exit(exitStatus);
+                if (exitStatus == -1)
+                    exit(errno);
+                else
+                    exit(0);
                 break;
             
             // main process
@@ -198,8 +202,9 @@ void rootshExec_execute_command(char* commandStr) {
                 snprintf(errnoNb, 5, "%d", WEXITSTATUS(childStatus));
 
                 Error err = rootshError_new_error();
-                rootshError_set_error_with_argument(err, "Unexcpected error. ERRNO", errnoNb);
-                rootshError_print_new_error("An unexpected error happened while executing the command");
+                rootshError_set_error_with_argument(err, "Unexcpected error", errnoNb);
+                rootshError_print_error(err);
+                rootshError_destroy_error(err);
                 break;
             }
         }

--- a/src/execCommand.c
+++ b/src/execCommand.c
@@ -191,10 +191,16 @@ void rootshExec_execute_command(char* commandStr) {
 
             // check child return code
             switch (WEXITSTATUS(childStatus)) {
-            case 0: // no error    
+            case 0: // no error
                 break;
             case EACCES: // permission denied
                 rootshError_print_new_error("Permission denied");
+                break;
+            case ENOENT: // File not found
+                rootshError_print_new_error("File not found");
+                break;
+            case EEXIST: // File exist
+                rootshError_print_new_error("File already exist");
                 break;
             
             default:

--- a/src/execCommand.h
+++ b/src/execCommand.h
@@ -9,6 +9,7 @@
 #include <errno.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <sys/wait.h>
 #include "constants.h"
 #include "parseInput.h"
 #include "list.h"

--- a/src/list.c
+++ b/src/list.c
@@ -82,3 +82,16 @@ void rootshList_printListString(List lst) {
     }
     printf("\"%s\"]\n", (char*)(tmp->v));
 }
+
+int rootshList_size(List lst) {
+    if (lst == NULL) return 0;
+
+    List tmp = lst;
+    int size = 1;
+    while (tmp->next != NULL) {
+        tmp = tmp->next;
+        size++;
+    }
+
+    return size;
+}

--- a/src/list.h
+++ b/src/list.h
@@ -87,4 +87,11 @@ List rootshList_push(List lst, void *elem);
  */
 void rootshList_printListString(List lst);
 
+/**
+ * Get the size of a list
+ * 
+ * @param lst   The list to get the size of
+ */
+int rootshList_size(List lst);
+
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -12,11 +12,11 @@ int main (int argc, char** argv) {
     int running = 1;
     char buffer[ROOTSH_MAX_COMMAND_LENGTH];
     int index = 0;
-    Error error = rootshError_new_error();
 
     while (running) {
         char c = getchar();
 
+        // user pressed enter
         if (c==10) {
             
             buffer[index] = '\0';
@@ -26,13 +26,19 @@ int main (int argc, char** argv) {
                 rootshExec_execute_command(buffer);
             index=0;
 
-        }else {
+        }
+
+        // user pressed ctrl + d
+        else if (c == EOF) {
+            running = FALSE;
+        }
+
+        // anything else
+        else {
             buffer[index] = c;
             index++;
         }
     }
-
-    rootshError_destroy_error(error);
 
     return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -20,7 +20,10 @@ int main (int argc, char** argv) {
         if (c==10) {
             
             buffer[index] = '\0';
-            rootshExec_execute_command(buffer);
+            if (strncmp(buffer, "exit", ROOTSH_MAX_COMMAND_LENGTH) == 0)
+                running = FALSE;
+            else
+                rootshExec_execute_command(buffer);
             index=0;
 
         }else {

--- a/src/makefile
+++ b/src/makefile
@@ -26,7 +26,7 @@ valgrind: compile
 	@valgrind ./$(EXEC)
 
 valgrind-full: compile
-	@valgrind --leak-check=full ./$(EXEC)
+	@valgrind --leak-check=full --show-leak-kinds=all --trace-children=yes ./$(EXEC)
 
 #	 Get dependancies
 OBJECTS := $(patsubst %.c, %.o, $(wildcard *.c))

--- a/src/parseInput.h
+++ b/src/parseInput.h
@@ -67,8 +67,8 @@ List rootshInput_splitInput(char *command);
  * Check in the List "command" if there are redirection and they are correctly made, if not return error message in argument `error`
  * 
  * @param command       The list of argument to check
- * @param error         Error message if 0 is returned, `NULL` else
- * @return 1 if the command is correctly redirected, 0 else
+ * @param error         Error message if -1 is returned, `NULL` else
+ * @return 0 if the command is correctly redirected, -1 else
  */
 int rootshInput_checkRedirect(List command, Error error);
 


### PR DESCRIPTION
closes #3 

- Find executable
- Put the argument of the command as a list
- Handle file & command from the `PATH` env var
- Fix memory leaks
- Handle error returned by the `execvp` function
- Add relevant comments
- Add way to exit shell (`exit` command and `ctrl + d`)
